### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,6 +15,8 @@ jobs:
   detect_changes:
     name: Detect Relevant Changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       should_deploy: ${{ steps.filter.outputs.should_deploy }}
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/w00k1337/DLicious/security/code-scanning/1](https://github.com/w00k1337/DLicious/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `detect_changes` job. Since this job only needs to read the repository contents to detect changes, we will set `contents: read` as the minimal required permission. This ensures adherence to the principle of least privilege and mitigates potential security risks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
