### PR TITLE
ci: add potential fix for code scanning alert no. 7

### DIFF
--- a/.github/workflows/registry-cleanup.yml
+++ b/.github/workflows/registry-cleanup.yml
@@ -95,6 +95,8 @@ jobs:
   cleanup-summary:
     name: Cleanup Summary
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [cleanup-main-images, cleanup-build-cache]
     if: always()
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/w00k1337/DLicious/security/code-scanning/7](https://github.com/w00k1337/DLicious/security/code-scanning/7)

To fix the problem, explicitly specify a `permissions` block on the `cleanup-summary` job, defining the minimal access required. Since the job's steps only read job results and log output, it does not require any special repository or package access. The most restrictive form is to set all permissions to `none`, but at minimum, setting `contents: read` establishes a safe default. This change should be made by inserting `permissions:` directly under `runs-on:` (line 98 or 99) in the `cleanup-summary` job definition in `.github/workflows/registry-cleanup.yml`. No additional methods, imports, or job modifications are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
